### PR TITLE
Fix `condition handler does not exist' issue

### DIFF
--- a/src/main/java/net/lomeli/achieveson/AchieveSON.java
+++ b/src/main/java/net/lomeli/achieveson/AchieveSON.java
@@ -26,7 +26,7 @@ public class AchieveSON {
         Logger.logInfo("Initializing basic packet handler...");
         PacketHandler.init();
         Logger.logInfo("Registering base condition handlers...");
-        ConditionHandler.conditionManager = new ConditionManager();
+        ConditionHandler.conditionManager = ConditionManager.getInstance();
         ConditionHandler.registerHandler(ConditionItemPickup.class);
         ConditionHandler.registerHandler(ConditionKillEntity.class);
         ConditionHandler.registerHandler(ConditionBlock.class);

--- a/src/main/java/net/lomeli/achieveson/conditions/ConditionManager.java
+++ b/src/main/java/net/lomeli/achieveson/conditions/ConditionManager.java
@@ -13,10 +13,10 @@ import net.lomeli.achieveson.network.MessageUnlockAchievement;
 import net.lomeli.achieveson.network.PacketHandler;
 
 public class ConditionManager implements IConditionManager {
-    public static ConditionManager instance;
+    private static ConditionManager instance;
     private HashMap<String, ConditionHandler> registeredConditions;
 
-    public ConditionManager() {
+    private ConditionManager() {
         registeredConditions = new HashMap<String, ConditionHandler>();
     }
 


### PR DESCRIPTION
I have tested with your example on wiki and could not trigger any achievement. In `fml-client-latest.log`, I found these lines:

```
[13:37:40] [Client thread/INFO] [achieveson/achieveson]: Creating achievement breakBlock for page Example-Achievements
[13:37:40] [Client thread/INFO] [achieveson/achieveson]: Assigning achievement breakBlock to condition handler block.
[13:37:40] [Client thread/WARN] [achieveson/achieveson]: Condition handler with that id does not exist!
```

After checking your code, I find out that the condition manager used in gaming will always have an empty `registeredConditions` since `ConditionManager` is not a safe singleton class. So I make this pull request to fix the issue.
